### PR TITLE
Remove click blocking :after mask when card is .active

### DIFF
--- a/dist/stackedCards.css
+++ b/dist/stackedCards.css
@@ -28,6 +28,9 @@
     right: 0;
     top: 0;
 }
+.stacked-cards li.active:after {
+    display: none;
+}
 .stacked-cards li img {
     position: relative;
     display: block;


### PR DESCRIPTION
This is the other small improvement; it's a simple change in the css file only. It removes the :after mask on the active card so that any links or buttons on the card are clickable. The :after mask would be reapplied once a card loses the .active class.